### PR TITLE
Deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Deprecated
 
 This project is no longer under active development.
-
-Please use [cargo-release](https://github.com/sunng87/cargo-release) instead.
+Your best bet might be https://medium.com/@jondot/shipping-rust-binaries-with-goreleaser-d5aa42a46be0.
+Please let us know if you find a better solution and we'll update that section.
 
 # cargo-deliver
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Deprecated
+
+This project is no longer under active development.
+
+Please use [cargo-release](https://github.com/sunng87/cargo-release) instead.
+
 # cargo-deliver
 
 


### PR DESCRIPTION
My google searches and documentation trail led me here first, but it looks like `cargo-releaser` is the current active project that people should be going to.

I made this assuming that to be the case. If not, disregard.